### PR TITLE
Peer review

### DIFF
--- a/README.adoc
+++ b/README.adoc
@@ -218,24 +218,24 @@ Wait until your cluster is in the `normal` state before proceeding. It will star
 
 [role="no_copy"]
 ----
-Name            ID                                 State       Created         Workers   Location   Version        Resource Group Name   
-guide-cluster   d1229f539ee902ca91g6d187c2dxy5s3   deploying   4 minutes ago   1         Dallas     1.10.11_1536   default 
+Name            ID                     State       Created          Workers   Location   Version       Resource Group Name   Provider   
+guide-cluster   bpp5ge4f0ck66fue46vg   deploying   4 minutes ago    1         par01      1.16.8_1526   Default               classic 
 ----
 
 Next, it will transition to the `pending` state.
 
 [role="no_copy"]
 ----
-Name            ID                                 State       Created         Workers   Location   Version        Resource Group Name   
-guide-cluster   d1229f539ee902ca91g6d187c2dxy5s3   pending     19 minutes ago   1        Dallas     1.10.11_1536   default 
+Name            ID                     State    Created          Workers   Location   Version       Resource Group Name   Provider   
+guide-cluster   bpp5ge4f0ck66fue46vg   pending  16 minutes ago   1         par01      1.16.8_1526   Default               classic 
 ----
 
 Finally, it will transition to the `normal` state. It may take a while for IKS to prepare your cluster.
 
 [role="no_copy"]
 ----
-Name            ID                                 State       Created         Workers   Location   Version        Resource Group Name   
-guide-cluster   d1229f539ee902ca91g6d187c2dxy5s3   normal      4 hours ago     1         Dallas     1.10.11_1536   default 
+Name            ID                     State    Created      Workers   Location   Version       Resource Group Name   Provider   
+guide-cluster   bpp5ge4f0ck66fue46vg   normal   1 hour ago   1         par01      1.16.8_1526   Default               classic
 ----
 
 
@@ -256,7 +256,7 @@ kubectl get nodes
 [source, role="no_copy"]
 ----
 NAME           STATUS    ROLES     AGE       VERSION
-10.70.200.73   Ready     <none>    1h        v1.10.11+IKS
+10.70.200.73   Ready     <none>    1h        v1.16.8+IKS
 ----
 
 // =================================================================================================
@@ -267,7 +267,7 @@ NAME           STATUS    ROLES     AGE       VERSION
 
 In this section, you will learn how to deploy two microservices in Open Liberty containers to a {kube}
 cluster on IBM Cloud. You will build and containerize the `system` and `inventory` microservices,
-push them to a container registry and, then deploy them to your {kube} cluster. 
+push them to a container registry, and then deploy them to your {kube} cluster. 
 
 // =================================================================================================
 // Building and containerizing the microservices
@@ -480,6 +480,20 @@ The following table gives an overview for each of the parameters specified using
 | `ssl.enabled` | Specify if SSL is enabled
 |===
 
+Use the following command to find the status of the pods running the `system` and `inventory` microservices. Wait until the status of both microservices is `Running`.
+
+[role=command]
+```
+kubectl get pods
+```
+
+[source, role="no_copy"]
+----
+NAME                                        READY     STATUS    RESTARTS   AGE
+inventory-app-ibm-open-l-5c586b9cfc-h5zmg   1/1       Running   0          23s
+system-app-ibm-open-libe-84976bccfb-r22lj   1/1       Running   0          23s
+----
+
 === Finding the microservice's IP address and ports
 
 The service used to expose our deployments has a type of `NodePort`. This means you can 
@@ -503,8 +517,8 @@ substitute into commands later in this guide.
 [role="no_copy"]
 ----
 OK
-ID                            Public IP       Private IP     Machine Type    State    Status   Zone    Version   
-kube-hou02-pad15e5f9-w1       172.173.65.24   10.77.198.71   free            normal   Ready    hou02   1.10.11_1538*
+ID                                                       Public IP         Private IP       Flavor   State    Status   Zone    Version   
+kube-bpp5ge4f0ck66fue46vg-guidecluste-default-00000048   159.122.179.207   10.144.188.209   free     normal   Ready    mil01   1.16.8_1526 
 ----
 
 Get the node port of the `system` microservice.

--- a/README.adoc
+++ b/README.adoc
@@ -687,8 +687,8 @@ kubectl get pods
 [source, role="no_copy"]
 ----
 NAME                                        READY     STATUS    RESTARTS   AGE
-inventory-app-ibm-open-l-5c586b9cfc-h5zmg   1/1       Running   0          23s
-system-app-ibm-open-libe-84976bccfb-r22lj   1/1       Running   0          2m15sm
+inventory-app-ibm-open-l-5c586b9cfc-h5zmg   1/1       Running   0          5m
+system-app-ibm-open-libe-84976bccfb-r22lj   1/1       Running   0          23s
 ----
 
 Observe that in this case the `system` microservice is running in the pod called `system-app-ibm-open-libe-84976bccfb-r22lj`. Substitute the name of your pod into the following command to see more details about the pod.
@@ -725,6 +725,13 @@ When you no longer need your deployed microservices, you can delete them with th
 ```
 helm uninstall system-app
 helm uninstall inventory-app
+```
+
+Remove the namespace you created in your container registry.
+
+[role=command]
+```
+ibmcloud cr namespace-rm [your-namespace]
 ```
 
 Log out of your container registry.

--- a/finish/inventory/pom.xml
+++ b/finish/inventory/pom.xml
@@ -64,6 +64,12 @@
             <version>3.2.6</version>
             <scope>test</scope>
         </dependency>
+        <!-- Support for Java 9 and above -->
+        <dependency>
+            <groupId>javax.xml.bind</groupId>
+            <artifactId>jaxb-api</artifactId>
+            <version>2.3.1</version>
+        </dependency>
     </dependencies>
 
     <build>

--- a/start/inventory/pom.xml
+++ b/start/inventory/pom.xml
@@ -64,6 +64,12 @@
             <version>3.2.6</version>
             <scope>test</scope>
         </dependency>
+        <!-- Support for Java 9 and above -->
+        <dependency>
+            <groupId>javax.xml.bind</groupId>
+            <artifactId>jaxb-api</artifactId>
+            <version>2.3.1</version>
+        </dependency>
     </dependencies>
 
     <build>

--- a/start/inventory/src/test/java/it/io/openliberty/guides/inventory/InventoryEndpointIT.java
+++ b/start/inventory/src/test/java/it/io/openliberty/guides/inventory/InventoryEndpointIT.java
@@ -50,12 +50,12 @@ public class InventoryEndpointIT {
         sysUrl = "http://" + clusterIp + ":" + sysNodePort + "/system/properties/";
 
         client = ClientBuilder.newBuilder()
-        .hostnameVerifier(new HostnameVerifier() {
-            public boolean verify(String hostname, SSLSession session) {
-                return true;
-            }
-        })
-        .build();
+                .hostnameVerifier(new HostnameVerifier() {
+                    public boolean verify(String hostname, SSLSession session) {
+                        return true;
+                    }
+                })
+                .build();
 
         client.register(JsrJsonpProvider.class);
         client.target(invUrl + "reset").request().post(null);


### PR DESCRIPTION
### Creating a Kubernetes cluster on IBM Cloud

- [x] CLI looks a bit different now for `ibmcloud ks clusters`

- [x] Output of the last `ibmcloud ks clusters` we run (when the state = normal) has an age of 4 hours, but the next command `kubectl get nodes` returns an age of 1 hour. maybe we should alter the timestamps so it's a bit shorter. Might make more sense for the timeline of the guide. Took around 20mins to get to normal state for me.

### Deploying microservices to IBM Cloud Kubernetes Service (IKS)

- [x] `container registry and, then deploy them to` The comma right of "and" does not seem correct. It should before it.

- [x] The outputs are different (mine says flavor, current says machine type

### Testing microservices that are running on IBM Cloud

- [x] issue running tests
```
[INFO] Scanning for projects...
[WARNING] 
[WARNING] Some problems were encountered while building the effective model for io.openliberty.guides:system:war:1.0-SNAPSHOT
[WARNING] 'parent.version' is either LATEST or RELEASE (both of them are being deprecated) @ io.openliberty.guides:kube-demo:1.0-SNAPSHOT, /root/jimbo/guide-cloud-ibm/start/pom.xml, line 11, column 18
[WARNING] 'dependencyManagement.dependencies.dependency.version' for io.openliberty.features:features-bom:pom is either LATEST or RELEASE (both of them are being deprecated) @ io.openliberty.guides:kube-demo:1.0-SNAPSHOT, /root/jimbo/guide-cloud-ibm/start/pom.xml, line 45, column 25
[WARNING] 
[WARNING] Some problems were encountered while building the effective model for io.openliberty.guides:kube-demo:pom:1.0-SNAPSHOT
[WARNING] 'parent.version' is either LATEST or RELEASE (both of them are being deprecated) @ line 11, column 18
[WARNING] 'dependencyManagement.dependencies.dependency.version' for io.openliberty.features:features-bom:pom is either LATEST or RELEASE (both of them are being deprecated) @ line 45, column 25
[WARNING] 
[WARNING] It is highly recommended to fix these problems because they threaten the stability of your build.
[WARNING] 
[WARNING] For this reason, future Maven versions might no longer support building such malformed projects.
[WARNING] 
[INFO] ------------------------------------------------------------------------
[INFO] Reactor Build Order:
[INFO] 
[INFO] kube-demo                                                          [pom]
[INFO] system                                                             [war]
[INFO] inventory                                                          [war]
...download from central...
[INFO] 
[INFO] ------------------< io.openliberty.guides:kube-demo >-------------------
[INFO] Building kube-demo 1.0-SNAPSHOT                                    [1/3]
[INFO] --------------------------------[ pom ]---------------------------------
[INFO] 
[INFO] --- maven-failsafe-plugin:3.0.0-M1:integration-test (default-cli) @ kube-demo ---
[INFO] No tests to run.
[INFO] 
[INFO] --------------------< io.openliberty.guides:system >--------------------
[INFO] Building system 1.0-SNAPSHOT                                       [2/3]
[INFO] --------------------------------[ war ]---------------------------------
[INFO] 
[INFO] --- maven-failsafe-plugin:3.0.0-M1:integration-test (default-cli) @ system ---
[INFO] 
[INFO] ------------------< io.openliberty.guides:inventory >-------------------
[INFO] Building inventory 1.0-SNAPSHOT                                    [3/3]
[INFO] --------------------------------[ war ]---------------------------------
[INFO] 
[INFO] --- maven-failsafe-plugin:3.0.0-M1:integration-test (default-cli) @ inventory ---
[INFO] ------------------------------------------------------------------------
[INFO] Reactor Summary for kube-demo 1.0-SNAPSHOT:
[INFO] 
[INFO] kube-demo .......................................... SUCCESS [  1.572 s]
[INFO] system ............................................. SUCCESS [  2.237 s]
[INFO] inventory .......................................... SUCCESS [  0.213 s]
[INFO] ------------------------------------------------------------------------
[INFO] BUILD SUCCESS
[INFO] ------------------------------------------------------------------------
[INFO] Total time:  8.179 s
[INFO] Finished at: 2020-03-30T06:37:49-07:00
[INFO] ------------------------------------------------------------------------

```

### Deploying new version of system microservice

- [x] should we add a `kubectl get pods` to check the pod state after we deploy using helm the first time too (before we do the cURL requests)? we check the pod state when we update the pod using helm upgrade, but not when we deploy the first time.

- [x] timestamps don't make sense. we upgraded the system app, so the system app's age should be less than the inventory app's age. Also `2m15sm` does not look right.
```
NAME                                        READY     STATUS    RESTARTS   AGE
inventory-app-ibm-open-l-5c586b9cfc-h5zmg   1/1       Running   0          23s
system-app-ibm-open-libe-84976bccfb-r22lj   1/1       Running   0          2m15sm
```

- [x] Is this warning expected after running `kubectl describe pod [system-app-podname]`?
` Warning  Unhealthy  9m58s  kubelet, 10.144.188.209  Readiness probe failed: Get http://172.30.200.205:9080/: dial tcp 172.30.200.205:9080: connect: connection refused`

### Tearing down the environment

- [x] Should we add a part to delete the container registry namespace?

###  Formatting & Presentation
- [x] minor indentation difference in `InventoryEndpointIT.java` files
```
client = ClientBuilder.newBuilder()
                .hostnameVerifier(new HostnameVerifier() {
                    public boolean verify(String hostname, SSLSession session) {
                        return true;
                    }
                })
                .build();
```

### Functionality
- [x] running into error with IT test
```
[ERROR] Tests run: 1, Failures: 0, Errors: 1, Skipped: 0, Time elapsed: 0.349 s <<< FAILURE! - in it.io.openliberty.guides.inventory.InventoryEndpointIT
[ERROR] it.io.openliberty.guides.inventory.InventoryEndpointIT  Time elapsed: 0.349 s  <<< ERROR!
java.lang.NoClassDefFoundError: javax.xml.bind.JAXBException
	at it.io.openliberty.guides.inventory.InventoryEndpointIT.oneTimeSetup(InventoryEndpointIT.java:61)
Caused by: java.lang.ClassNotFoundException: javax.xml.bind.JAXBException
	at it.io.openliberty.guides.inventory.InventoryEndpointIT.oneTimeSetup(InventoryEndpointIT.java:61)

[INFO]
[INFO] Results:
[INFO]
[ERROR] Errors:
[ERROR]   InventoryEndpointIT.oneTimeSetup:61 » NoClassDefFound javax.xml.bind.JAXBExcep...
[INFO]
[ERROR] Tests run: 1, Failures: 0, Errors: 1, Skipped: 0
```


